### PR TITLE
Use Makefile targets rather than shell scripts directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Notice how the `Failed requests` is now 0. This means that all of the 10,000+ re
 
 ## Tear Down
 
-Deleting the deployments is accomplished by executing `teardown.sh`. It will run `terraform destroy` which will destroy all of the resources created for this demonstration.
+Deleting the deployments is accomplished by executing `make teardown`. It will run `terraform destroy` which will destroy all of the resources created for this demonstration.
 
 ![screenshot](./images/tear-down.png)
 
@@ -224,7 +224,7 @@ For additional information see: [Embarking on a Journey Towards Containerizing Y
 
 Occasionally the APIs take a few moments to complete. Running `make validate` immediately could potentially appear to fail, but in fact the instances haven't finished initializing. Waiting for a minute or two should resolve the issue.
 
-The setup of this demo **does** take up to **15** minutes. If there is no error the best thing to do is keep waiting. The execution of `setup.sh` should **not** be interrupted.
+The setup of this demo **does** take up to **15** minutes. If there is no error the best thing to do is keep waiting. The execution of `make create` should **not** be interrupted.
 
 If you do get an error, it probably makes sense to re-execute the failing script. Occasionally there are network connectivity issues, and retrying will likely work the subsequent time.
 


### PR DESCRIPTION
Found uses of `teardown.sh` and a (nonexistent) `setup.sh` that should be corrected.