### PR TITLE
Qwiklabs GSP475 - feature pack. TF 0.12+ and Bash defect

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -31,7 +31,6 @@ COPY prime-flask-server.py requirements.txt /opt/
 
 RUN adduser -D apprunner && \
     apk add --no-cache \
-    bash=4.4.19-r1 \
     dumb-init=1.2.2-r1 && \
     pip3 install -r /opt/requirements.txt && \
     chown -R apprunner:apprunner /opt/

--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -33,7 +33,7 @@ run_terraform() {
 
   (cd "$ROOT/terraform"; terraform init -input=false)
   (cd "$ROOT/terraform"; terraform apply -input=false -auto-approve \
-    -var version="$VERSION")
+    -var ver="$VERSION")
 }
 
 wait_for_cluster() {

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -27,4 +27,4 @@ rm -f "${ROOT}/terraform/manifests/prime-server-deployment.yaml"
 check_dependency_installed terraform
 
 (cd "${ROOT}/terraform" && terraform destroy \
-   -var version="$VERSION" -auto-approve)
+   -var ver="$VERSION" -auto-approve)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -79,7 +79,7 @@ EOF
 
   vars {
     project      = "${var.project}"
-    version      = "${var.version}"
+    version      = "${var.ver}"
   }
 }
 
@@ -169,7 +169,7 @@ EOF
 
   vars {
     project   = "${var.project}"
-    version   = "${var.version}"
+    version   = "${var.ver}"
     replicas  = "${var.replicas}"
   }
 }
@@ -208,7 +208,7 @@ resource "google_storage_bucket" "artifact_store" {
 
 // https://www.terraform.io/docs/providers/google/r/storage_bucket_object.html
 resource "google_storage_bucket_object" "artifact" {
-  name          = "${var.version}/flask-prime.tgz"
+  name          = "${var.ver}/flask-prime.tgz"
   source        = "../build/flask-prime.tgz"
   bucket        = "${google_storage_bucket.artifact_store.name}"
   // TODO: ignore lifecycle something so old versions don't get deleted
@@ -218,7 +218,7 @@ data "template_file" "web_init" {
   template = "${file("${path.module}/web-init.sh.tmpl")}"
   vars {
     bucket  = "${var.project}-vm-artifacts"
-    version = "${var.version}"
+    version = "${var.ver}"
   }
 }
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -14,24 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 output "prime_web_server" {
-  value = "http://${google_compute_instance.web_server.network_interface.0.access_config.0.assigned_nat_ip}:8080/prime"
+  value = "http://${google_compute_instance.web_server.network_interface.0.access_config.0.nat_ip}:8080/prime"
 }
 
 output "factorial_web_server" {
-  value = "http://${google_compute_instance.web_server.network_interface.0.access_config.0.assigned_nat_ip}:8080/factorial"
+  value = "http://${google_compute_instance.web_server.network_interface.0.access_config.0.nat_ip}:8080/factorial"
 }
 
 output "web_server_address" {
-  value = "http://${google_compute_instance.web_server.network_interface.0.access_config.0.assigned_nat_ip}:8080"
+  value = "http://${google_compute_instance.web_server.network_interface.0.access_config.0.nat_ip}:8080"
 }
 output "prime_cos_server" {
-  value = "http://${google_compute_instance.container_server.network_interface.0.access_config.0.assigned_nat_ip}:8080/prime"
+  value = "http://${google_compute_instance.container_server.network_interface.0.access_config.0.nat_ip}:8080/prime"
 }
 
 output "factorial_cos_server" {
-  value = "http://${google_compute_instance.container_server.network_interface.0.access_config.0.assigned_nat_ip}:8080/factorial"
+  value = "http://${google_compute_instance.container_server.network_interface.0.access_config.0.nat_ip}:8080/factorial"
 }
 
 output "cos_server_address" {
-  value = "http://${google_compute_instance.container_server.network_interface.0.access_config.0.assigned_nat_ip}:8080"
+  value = "http://${google_compute_instance.container_server.network_interface.0.access_config.0.nat_ip}:8080"
 }

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -21,13 +21,13 @@ limitations under the License.
 
 
 provider "google" {
-  version = "~> v1.16"
+  version = "~> v2.9.1"
 }
 
 provider "null" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
 }
 
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -35,7 +35,7 @@ variable "replicas" {
   default = "1"
 }
 
-variable "version" {
+variable "ver" {
   type = "string"
 }
 


### PR DESCRIPTION
Fix applied to correct behaviours reported on the qwiklabs environment. 

These are the changes to update the gke migration to containers repo to for Bash and Terraform defects.

**A. Dockerfile**
In the Dockerfile removed the reference to outdated bash version. 

**B. Main.tf**
"version" is a now reserved keyword in Terraform v0.12+. Change the variable name from "version" to "ver".

**C. Provider.tf**
Provider.tf uses version components that are outdated, upgrade to a minimum of the versions below:
1. provider "google" from v1.16 to v2.9.1
2. provider "null" from 1.0 to 2.1.2
3. provider "template" from 1.0 to 2.1.2

**D. Variables.tf**
variables.tf needs to be updated to reflect the variable change of "version" to "ver"

**E. Outputs .tf**
* Note: Not sure if this is a bug or a feature of the Google Provider, but the external IP address state is stored in the nat_ip rather than assigned_nat_ip value. In the previous version of Terraform this seems to be capable of retrieving this information from the assigned_nat_ip.

**F. Scripts directory**
1. Update the create.sh script to use the  field "var.ver" rather than "var.version"
2. Update the teardown.sh script to use the field "var.ver" rather than "var.version"
