### PR TITLE
Added method to create static IP

### DIFF
--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -36,6 +36,13 @@ run_terraform() {
     -var ver="$VERSION")
 }
 
+generate_static_ip() {
+    # Check to make sure static IP hasn't already been created, then register it.
+    if [[ $(gcloud compute addresses list | grep 'prime-server') = '' ]]; then
+        gcloud compute addresses create prime-server --global
+    fi
+}
+
 wait_for_cluster() {
   # Provisioning a Kubernetes Engine ingress can take some time as a Layer 7
   # http load balancer must be configured.  This script will check and loop-retry
@@ -172,6 +179,8 @@ enable_project_api "${PROJECT}" cloudbuild.googleapis.com
 run_build
 
 run_terraform
+
+generate_static_ip
 
 kubectl apply -f "${ROOT}/terraform/manifests/" --namespace default
 


### PR DESCRIPTION
![error (1)](https://user-images.githubusercontent.com/40506467/87086282-37bd1980-c1e6-11ea-8711-53647fff26c0.png)

I'm a Qwiklabs lab architect debugging a lab that uses this repo. We're currently hitting an error where the makefile create command timesout when trying to get the IP of the ingress in the "wait_for_cluster()" method in the "create.sh" script.

The IP for the ingress is empty even after extending the timeout duration, but it appears the yaml file for the ingress service is relying on a static IP which is never set up.

After creating the global static IP with the "gcloud compute addresses create prime-server --global" command, everything ran as intended. I only wrapped it in a method to make sure the command doesn't error out on multiple runs of "make create". 