### PR TITLE
pin image to working version for walkthrough

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -97,7 +97,7 @@ resource "google_compute_instance" "container_server" {
 
   boot_disk {
     initialize_params {
-      image = "cos-cloud/cos-stable"
+      image = "cos-cloud/cos-77-lts"
     }
   }
 


### PR DESCRIPTION
I'm a Qwiklabs architect and this repo is used as a demo in a lab. We're currently dealing with a bug where the user's ssh session with the COS vm gets disconnected after being connected for roughly 5-30 seconds.

We believe this to be a bug in the os login agents that run in the VM and have found that pinning the COS vm image to a slightly older issue resolves the issue.

This PR sets the COS vm image to the working version and merging it would fix our lab.