### PR TITLE
Fix for Migrating to GKE Containers as CloudShell is now TF 0.15.1

### DIFF
--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -19,14 +19,19 @@ limitations under the License.
 // specify the version of the Google Cloud Provider that was used to
 // develop this example.
 
-provider "google" {
-  version = "~> v2.11.0"
-}
+terraform {
+  required_providers {
+    google = {
+      version = "~> 2.11.0"
+    }
 
-provider "null" {
-  version = "~> 2.1.2"
-}
+    null = {
+      version = "~> 2.1.2"
+    }
 
-provider "template" {
-  version = "~> 2.1.2"
+
+    template = {
+      version = "~> 2.1.2"
+    }
+  }
 }


### PR DESCRIPTION
This is a fix to the provider versioning in TF 0.15.x as the previous provider versioning is no longer supported.

I've ran this change through in the Qwiklab and all now works.

This is the Qwiklab that is currently broken, that this fix resolves: 
[Migrating to GKE containers](https://google.qwiklabs.com/focuses/12768?catalog_rank=%7B%22rank%22%3A1%2C%22num_filters%22%3A1%2C%22has_search%22%3Atrue%7D&parent=catalog&search_id=6329675)