### PR TITLE
remove 'v' prefix in google provider version

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -128,11 +128,17 @@ check_dependency_installed terraform
 echo ""
 echo "Validating Debian VM Webapp..."
 SERVER_ADDRESS=$(cd "$ROOT/terraform" && terraform output web_server_address)
+# Remove surrounding quotes from URL
+SERVER_ADDRESS="${SERVER_ADDRESS%\"}"
+SERVER_ADDRESS="${SERVER_ADDRESS#\"}"
 validate_deployment "$SERVER_ADDRESS"
 
 echo ""
 echo "Validating Container OS Webapp..."
 SERVER_ADDRESS=$(cd "$ROOT/terraform" && terraform output cos_server_address)
+# Remove surrounding quotes from URL
+SERVER_ADDRESS="${SERVER_ADDRESS%\"}"
+SERVER_ADDRESS="${SERVER_ADDRESS#\"}"
 validate_deployment "$SERVER_ADDRESS"
 
 echo ""

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -20,7 +20,7 @@ limitations under the License.
 // develop this example.
 
 provider "google" {
-  version = "~> v2.11.0"
+  version = "~> 2.11.0"
 }
 
 provider "null" {


### PR DESCRIPTION
'v' prefix not accepted by modern terraform versions. This update fixes Qwiklab and allows easy use with Cloud Shell.

@kaariger 