### PR TITLE
Updated to cos-81-lts due to cos-77-lts deprecation

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -97,7 +97,7 @@ resource "google_compute_instance" "container_server" {
 
   boot_disk {
     initialize_params {
-      image = "cos-cloud/cos-89-lts"
+      image = "cos-cloud/cos-stable"
     }
   }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -97,7 +97,7 @@ resource "google_compute_instance" "container_server" {
 
   boot_disk {
     initialize_params {
-      image = "cos-cloud/cos-81-lts"
+      image = "cos-cloud/cos-89-lts"
     }
   }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -97,7 +97,7 @@ resource "google_compute_instance" "container_server" {
 
   boot_disk {
     initialize_params {
-      image = "cos-cloud/cos-77-lts"
+      image = "cos-cloud/cos-81-lts"
     }
   }
 


### PR DESCRIPTION
cos-77-lts has been deprecated since April 2021 according to [https://cloud.google.com/container-optimized-os/docs/release-notes#Archived](url). In order for the "make deploy" to succeed, it has to be updated to cos-81-lts.
This solved the deployment problem on a Qwiklabs lab (Migrating to GKE Containers).

Regards
Ferran