### PR TITLE
Fix: replace location, add compute-rw

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -17,7 +17,7 @@ limitations under the License.
 // Provides access to available Google Container Engine versions in a zone for a given project.
 // https://www.terraform.io/docs/providers/google/d/google_container_engine_versions.html
 data "google_container_engine_versions" "on-prem" {
-  zone    = "${var.zone}"
+  location = "${var.zone}"
   project = "${var.project}"
 }
 
@@ -113,7 +113,7 @@ resource "google_compute_instance" "container_server" {
   }
 
   service_account {
-    scopes = ["storage-ro"]
+    scopes = ["storage-ro", "compute-rw"]
   }
 
 }
@@ -249,7 +249,7 @@ resource "google_compute_instance" "web_server" {
   metadata_startup_script = "${data.template_file.web_init.rendered}"
 
   service_account {
-    scopes = ["storage-ro"]
+    scopes = ["storage-ro", "compute-rw"]
   }
 
   depends_on = [


### PR DESCRIPTION
Amend a couple of setting in Terraform.

- [x] Replace `zone` with location as per google_container_engine_versions setting
- [x] Update `vm-webserver` setting to allow `compute-rw` permission for SSH access
- [x] Update `cos-vm` setting to allow `compute-rw` permission for SSH access

Ref: b/199400322