### PR TITLE
Update prime-server-ingress.yaml

### DIFF
--- a/container/requirements.txt
+++ b/container/requirements.txt
@@ -1,2 +1,3 @@
 flask==1.1.1
 gunicorn==19.9.0
+itsdangerous==2.0.1

--- a/terraform/manifests/prime-server-ingress.yaml
+++ b/terraform/manifests/prime-server-ingress.yaml
@@ -15,13 +15,15 @@
 # Create an ingress to access the prime-server over the internet.
 # https://kubernetes.io/docs/concepts/services-networking/ingress/
 # https://cloud.google.com/kubernetes-engine/docs/tutorials/http-balancer
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: prime-server
   annotations:
     kubernetes.io/ingress.global-static-ip-name: "prime-server"
 spec:
-  backend:
-    serviceName: prime-server
-    servicePort: 8080
+  defaultBackend:
+    service:
+      name: prime-server
+      port:
+        number: 8080


### PR DESCRIPTION
updated deprecated api version and updated spec syntax.

https://cloud.google.com/kubernetes-engine/docs/release-notes#deprecated_apis
https://v1-19.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#ingressbackend-v1-networking-k8s-io
https://stackoverflow.com/questions/64125048/get-error-unknown-field-servicename-in-io-k8s-api-networking-v1-ingressbacken