### PR TITLE
use python3 for vm-webserver startup

### DIFF
--- a/container/install.sh
+++ b/container/install.sh
@@ -28,7 +28,7 @@ check_dependency_installed () {
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-check_dependency_installed "python"
-check_dependency_installed "pip"
+check_dependency_installed "python3"
+check_dependency_installed "pip3"
 
-pip install -r "${ROOT}/requirements.txt"
+pip3 install -r "${ROOT}/requirements.txt"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -231,7 +231,7 @@ tags = ["flask-web"]
 
 boot_disk {
 initialize_params {
-image = "debian-cloud/debian-9"
+image = "debian-cloud/debian-10"
 }
 }
 

--- a/terraform/web-init.sh.tmpl
+++ b/terraform/web-init.sh.tmpl
@@ -16,8 +16,8 @@
 # A newly booted VM will need to update package lists
 sudo apt-get update
 
-# Debian9 comes wth python2.7 by default, this installs the appropriate pip
-sudo apt-get install python-pip -y
+# Debian10 comes wth python3.7 by default, this installs the appropriate pip
+sudo apt-get install python3-pip -y
 
 # Create a user to run the application
 sudo adduser apprunner


### PR DESCRIPTION
With the recent Flask upgrade for this repo, we're now encountering an error when the vm-webserver attempts to pip install the requirements. Python2 pip does not have Flask >= 2.0.

This updates the webserver to use python3.

The change to Debian-10 in terraform is not necessary, but it didn't break anything and may help future-proof the code.