### PR TITLE
update conditional for static IP creation

### DIFF
--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -38,7 +38,7 @@ run_terraform() {
 
 generate_static_ip() {
     # Check to make sure static IP hasn't already been created, then register it.
-    if [[ $(gcloud compute addresses list | grep ' prime-server') = '' ]]; then
+    if [[ $(gcloud compute addresses list | grep '^NAME:\sprime-server') = '' ]]; then
         gcloud compute addresses create prime-server --global
     fi
 }

--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -38,7 +38,7 @@ run_terraform() {
 
 generate_static_ip() {
     # Check to make sure static IP hasn't already been created, then register it.
-    if [[ $(gcloud compute addresses list | grep 'prime-server') = '' ]]; then
+    if [[ $(gcloud compute addresses list | grep ' prime-server') = '' ]]; then
         gcloud compute addresses create prime-server --global
     fi
 }


### PR DESCRIPTION
There's a static IP address now being created by the cluster that has 'prime-server' in its name. Our current script matches with this other address, doesn't create the global static IP, and the Ingress is never successfully created/connected.

Changing the pattern fixes this issue.